### PR TITLE
remove key from _pendingRequests in case of timeout

### DIFF
--- a/RadiusClient.cs
+++ b/RadiusClient.cs
@@ -48,6 +48,10 @@ namespace Flexinets.Radius
                 {
                     return _radiusPacketParser.Parse(responseTaskCS.Task.Result.Buffer, packet.SharedSecret);
                 }
+                if (_pendingRequests.TryRemove((packet.Identifier, remoteEndpoint), out var taskCS))
+                {
+                    taskCS.SetCanceled();
+                }
                 throw new InvalidOperationException($"Receive response for id {packet.Identifier} timed out after {timeout}");
             }
             throw new InvalidOperationException($"There is already a pending receive with id {packet.Identifier}");


### PR DESCRIPTION
Hi,
 I found that in case of timeout the key (identifier, remoteEndpoint) was never removed from _pendingRequests dictionary. Thus that identifier was lost forever.
 